### PR TITLE
Updated label format when returned

### DIFF
--- a/instadam/project.py
+++ b/instadam/project.py
@@ -207,9 +207,9 @@ def add_label(project_id):
     project = maybe_get_project(project_id)
     req = request.get_json()
     
-    check_json(req, ['label_name', 'label_color'])
+    check_json(req, ['label_text', 'label_color'])
 
-    label_name = req['label_name']
+    label_name = req['label_text']
     label_color = req['label_color']
     if label_color[0] != '#' or not all(c in hexdigits
                                         for c in label_color[1:]):
@@ -233,8 +233,8 @@ def get_labels(project_id):
     project = maybe_get_project(project_id)
     labels = [{
         'color': label.label_color,
-        'name': label.label_name,
-        'id': label.id
+        'text': label.label_name,
+        'label_id': label.id
     } for label in project.labels]
     return jsonify({'labels': labels}), 200
 

--- a/tests/test_annotation_endpoint.py
+++ b/tests/test_annotation_endpoint.py
@@ -81,7 +81,7 @@ def image_label_uploaded(local_client):
         assert 'Image added successfully' == json_data['msg']
 
     rv = local_client.post(
-        '/project/1/labels', json={'label_name': 'my_label', 'label_color': '#000000'},
+        '/project/1/labels', json={'label_text': 'my_label', 'label_color': '#000000'},
         headers={'Authorization': 'Bearer %s' % access_token})
     assert '200 OK' == rv.status
     json_data = rv.get_json()

--- a/tests/test_label_endpoint.py
+++ b/tests/test_label_endpoint.py
@@ -68,7 +68,8 @@ def test_add_label(local_client):
     access_token = successful_login(local_client, 'test_upload_user1',
                                     'TestTest1')
     rv = local_client.post(
-        '/project/1/labels', json={'label_name': 'my_label', 'label_color': '#000000'},
+        '/project/1/labels',
+        json={'label_text': 'my_label', 'label_color': '#000000'},
         headers={'Authorization': 'Bearer %s' % access_token})
     assert '200 OK' == rv.status
     json_data = rv.get_json()
@@ -80,7 +81,8 @@ def test_get_label(local_client):
     access_token = successful_login(local_client, 'test_upload_user1',
                                     'TestTest1')
     rv = local_client.post(
-        '/project/1/labels', json={'label_name': 'my_label_1', 'label_color': '#001000'},
+        '/project/1/labels',
+        json={'label_text': 'my_label_1', 'label_color': '#001000'},
         headers={'Authorization': 'Bearer %s' % access_token})
     assert '200 OK' == rv.status
     json_data = rv.get_json()
@@ -88,7 +90,8 @@ def test_get_label(local_client):
     assert 'Label added successfully' == json_data['msg']
 
     rv = local_client.post(
-        '/project/1/labels', json={'label_name': 'my_label_2', 'label_color': '#000000'},
+        '/project/1/labels',
+        json={'label_text': 'my_label_2', 'label_color': '#000000'},
         headers={'Authorization': 'Bearer %s' % access_token})
     assert '200 OK' == rv.status
     json_data = rv.get_json()
@@ -106,5 +109,5 @@ def test_get_label(local_client):
     assert 2 == len(labels)
 
     for label in labels:
-        label_id = label['id']
-        assert 'my_label_%d' % label_id == label['name']
+        label_id = label['label_id']
+        assert 'my_label_%d' % label_id == label['text']


### PR DESCRIPTION
Now when listing labels, you will get (for example, key order could be different):
```
[
    {
        "color": "#0000",
        "text": "asdf",
        "label_id": 1
    }
]
```
And when you're creating label, you need to send:
```
{
    "label_text": "asdf",
    "label_color": "#0000"
}
```